### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SignalStrengthIndicator",
+    products: [
+        .library(
+            name: "SignalStrengthIndicator",
+            targets: ["SignalStrengthIndicator"]),
+    ],
+    dependencies: [
+    ],
+    path: "./SignalStrengthIndicator/Sources/",
+    targets: [
+        .target(
+            name: "SignalStrengthIndicator",
+            dependencies: []),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,10 @@ let package = Package(
     ],
     dependencies: [
     ],
-    path: "./SignalStrengthIndicator/Sources/",
     targets: [
         .target(
             name: "SignalStrengthIndicator",
-            dependencies: []),
+            dependencies: [],
+            path: "SignalStrengthIndicator/Sources/"),
     ]
 )


### PR DESCRIPTION
Allow SignalStrengthIndicator to be integrated into other projects using the Swift Package Manager (Xcode 12+)